### PR TITLE
make-generic

### DIFF
--- a/init.el
+++ b/init.el
@@ -7,7 +7,17 @@
 (unless noninteractive
   (message "Loading %s..." load-file-name))
 
-(load (expand-file-name "load-path" (file-name-directory load-file-name)))
+;; remember this directory and set as user directory (instead of .emacs.d)
+(setq start-dir
+      (file-name-directory (or load-file-name (buffer-file-name))))
+(setq user-emacs-directory start-dir)
+
+;; pre-ignition config variables
+(if (file-exists-p
+  (expand-file-name (concat user-login-name ".el") start-dir))
+  (load (expand-file-name user-login-name start-dir)))
+
+(load (expand-file-name "load-path" start-dir))
 
 (require 'use-package)
 (eval-when-compile

--- a/jwiegley.el
+++ b/jwiegley.el
@@ -1,0 +1,23 @@
+
+(setq override-dirs
+      (list
+       "override/bbdb/lisp/"
+       "override/gnus/contrib/"
+       "override/gnus/lisp/"
+       "override/org-mode/contrib/lisp/"
+       "override/org-mode/lisp/"
+       "override/tramp/lisp/"))
+
+;; Packages located elsewhere on the system...
+
+;;(setq misc-dirs nil)
+
+(setq misc-dirs (list
+                 "~/src/ledger/lisp/"
+                 "/usr/local/share/emacs/site-lisp/"
+                 "/opt/local/share/emacs/site-lisp/"
+                 "/opt/local/share/doc/git-core/contrib/emacs/"
+                 "/Users/johnw/Archives/Languages/Ruby/Sources/ruby/misc/"
+                 "/opt/local/share/texmf-texlive-dist/doc/latex/latex2e-help-texinfo/"
+                 ))
+ 

--- a/load-path.el
+++ b/load-path.el
@@ -26,27 +26,17 @@
     (if (cadr entry)
         (add-to-load-path (car entry) dir))))
 
-(mapc #'add-to-load-path
-      (nreverse
-       (list
-        user-emacs-directory
+(if (and (boundp 'misc-dirs)
+         misc-dirs)
+    (mapc #'add-to-load-path
+          (nreverse misc-dirs)))
 
-        "override/bbdb/lisp/"
-        "override/gnus/contrib/"
-        "override/gnus/lisp/"
-        "override/org-mode/contrib/lisp/"
-        "override/org-mode/lisp/"
-        "override/tramp/lisp/"
+(if (and (boundp 'override-dirs)
+         override-dirs)
+    (mapc #'add-to-load-path
+          (nreverse override-dirs)))
 
-        ;; Packages located elsewhere on the system...
-        "~/src/ledger/lisp/"
-
-        "/usr/local/share/emacs/site-lisp/"
-        "/opt/local/share/emacs/site-lisp/"
-        "/opt/local/share/doc/git-core/contrib/emacs/"
-        "/Users/johnw/Archives/Languages/Ruby/Sources/ruby/misc/"
-        "/opt/local/share/texmf-texlive-dist/doc/latex/latex2e-help-texinfo/"
-        )))
+(add-to-load-path user-emacs-directory)
 
 (let ((cl-p load-path))
   (while cl-p


### PR DESCRIPTION
Borrowed some patterns from starter-kit to get dotemacs to work out of
the box:
init.el : added a test to find out start-dir.  This means that the
dotemcs will work either as init files or as a load.
load-path.el : will work without override and misc directories
jwiegley.el : for username jwiegley works as before ;)
