### PR TITLE
Fix numeric argument in mark-line.

### DIFF
--- a/init.el
+++ b/init.el
@@ -251,6 +251,7 @@
   (beginning-of-line)
   (let ((here (point)))
     (dotimes (i arg)
+      (or (zerop i) (forward-line))
       (end-of-line))
     (set-mark (point))
     (goto-char here)))


### PR DESCRIPTION
Otherwise, the loop
 ```emacs-lisp
(dotimes (i arg)
  (end-of-line))
``` 
does'n do much ;)